### PR TITLE
Better "manual activity" support by preprocessing TCXs

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ const strava = require('./lib/strava');
 
 (async () => {
 
+  // preprocess TCX to fix manual entry workouts, so they include duration and distance
+  await strava.preprocess()
+
   // upload the tracks
   await strava.upload()
 

--- a/lib/files.js
+++ b/lib/files.js
@@ -67,6 +67,11 @@ const _getPropsFromJson = async (file) => {
   for (const prop of json){
     if (prop.sport) props.sport = prop.sport
     if (prop.created_date) props.created_date = prop.created_date
+    if (prop.start_time) props.start_time = prop.start_time
+    if (prop.end_time) props.end_time = prop.end_time
+    if (prop.duration_s) props.duration_s = prop.duration_s
+    if (prop.distance_km) props.distance_km = prop.distance_km
+    if (prop.notes) props.notes = prop.notes
   }
   return props;
 }

--- a/lib/strava-fix-activities.js
+++ b/lib/strava-fix-activities.js
@@ -14,24 +14,38 @@ const files = require('./files');
    but this will check all of them anyway
 */
 const SPORTMAP = {
+  BADMINTON: "Workout",
   BIKING: "Ride",
   CROSSFIT: "Crossfit",
   CYCLING_SPORT: "Ride",
   CYCLING_TRANSPORTATION: "Ride",
   FITNESS_WALKING: "Walk",
+  GOLFING: "Workout",
+  GYMNASTICS: "Workout",
   HIKING: "Hike",
+  KAYAKING: "Kayaking",
   MOUNTAIN_BIKING: "Ride",
+  ROWING_INDOOR: "Rowing",
   RUNNING: "Run",
   SKIING_CROSS_COUNTRY: "NordicSki",
   SKIING_DOWNHILL: "AlpineSki",
+  SNOWBOARDING: "Snowboard",
   SNOWSHOEING: "Snowshoe",
   SPINNING: "VirtualRide",
+  SQUASH: "Workout",
   STAIR_CLIMBING: "StairStepper",
   SWIMMING: "Swim",
+  TENNIS: "Workout",
   TREADMILL_RUNNING: "VirtualRun",
   TREADMILL_WALKING: "VirtualRun",
-  WALKING: "Walk"
+  WALKING: "Walk",
+  WEIGHT_TRAINING: "WeightTraining",
+  YOGA: "Yoga",
 }
+
+const _firstUpper = (string) => {
+  return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
+};
 
 module.exports = async (strava) => {
   const sportsFound = {};
@@ -46,7 +60,6 @@ module.exports = async (strava) => {
   let pageNumber = 0;
   let pagesRemaining = true;
   for (const file of jsonfiles){
-    const stravaExternalID = file.name.replace(/\.json$/,'tcx');
     // get json activity data and error check
     const jsonActivity = await files.getPropsFromJson(files.getFullPath(file.name))
     if (!jsonActivity.sport) {
@@ -89,26 +102,19 @@ module.exports = async (strava) => {
     // If we're here, we have the mapped JSON activity, and we've located the activity in Strava
     const thisStravaActivity = stravaActivities[jsonActivity.stravaExternalID];
     //console.log(`found ${jsonActivity.created_date} : ${thisStravaActivity.id}`);
-    // Does it match? Update or don't    
-    if (thisStravaActivity.type == SPORTMAP[jsonActivity.sport]){
-      console.log(`${jsonActivity.created_date} : ${jsonActivity.sport} correctly maps to ${thisStravaActivity.type} `);
+
+    try {
+      console.log(`**** ${jsonActivity.created_date} is ${jsonActivity.sport} and ${thisStravaActivity.type} in Strava. Updating to ${SPORTMAP[jsonActivity.sport]} and setting name and description`);
+      await strava.activities.update({
+        id: thisStravaActivity.id,
+        type: SPORTMAP[jsonActivity.sport],
+        name: thisStravaActivity.name.replace(new RegExp(thisStravaActivity.type), _firstUpper(jsonActivity.sport)),
+        description: jsonActivity.notes
+      });
       await files.success(file.name);
-    } else {
-      
-
-      try {
-        console.log(`**** ${jsonActivity.created_date} is ${jsonActivity.sport}, but ${thisStravaActivity.type} in Strava. Updating to ${SPORTMAP[jsonActivity.sport]}`);
-        await strava.activities.update({
-          id : thisStravaActivity.id,
-          type : SPORTMAP[jsonActivity.sport],
-          name : thisStravaActivity.name.replace(new RegExp(thisStravaActivity.type), SPORTMAP[jsonActivity.sport])
-        });
-        await files.success(file.name);
-      } catch (e) {
-        console.log(`failed to update activity ${jsonActivity.created_date} from ${thisStravaActivity.type} to ${SPORTMAP[jsonActivity.sport]} : ${e}`)
-        await files.failure(file.name);
-      }
-
+    } catch (e) {
+      console.log(`failed to update activity ${jsonActivity.created_date} from ${thisStravaActivity.type} to ${SPORTMAP[jsonActivity.sport]} : ${e}`)
+      await files.failure(file.name);
     }
   }
 

--- a/lib/strava-preprocess.js
+++ b/lib/strava-preprocess.js
@@ -1,0 +1,67 @@
+'use strict;'
+
+const files = require('./files');
+const parser = require('fast-xml-parser');
+const fs = require('fs');
+
+const _endDistance = (distance) => {
+  const r = Math.floor(distance * 1000);
+
+  if (isNaN(r))
+    return 0;
+
+  return r;
+}
+
+const _fixTime = (timeString) => {
+  return timeString.replace(' ', 'T');
+}
+
+module.exports = async () => {
+  const sportsFound = {};
+
+  // get tcx files
+  const tsxfiles = await files.getTcxFiles();
+  console.log(`found ${tsxfiles.length} TCX files in data source`);
+  if (tsxfiles.length == 0) return;
+
+  for (const file of tsxfiles) {
+    const content = fs.readFileSync(files.getFullPath(file.name), { encoding: 'utf-8' });
+    const json = parser.parse(content, {
+      ignoreAttributes: false,
+      ignoreNameSpace: false,
+    });
+
+    const lap = json?.TrainingCenterDatabase?.Activities?.Activity?.Lap;
+
+    if (lap) {
+      const trackpoint = lap?.Track?.Trackpoint;
+
+      if (trackpoint && Array.isArray(trackpoint)) {
+        console.log("Working as intended", file.name);
+      }
+      else {
+        console.log("Needs fix", file.name);
+        const jsonActivity = await files.getPropsFromJson(files.getFullPath(file.name.replace('tcx', 'json')))
+
+        lap.Track = {
+          Trackpoint: [{
+            Time: _fixTime(jsonActivity.start_time),
+            DistanceMeters: 0,
+          }, {
+            Time: _fixTime(jsonActivity.end_time),
+            DistanceMeters: _endDistance(jsonActivity.distance_km)
+          }]
+        };
+
+        const j2x = new parser.j2xParser({
+          attributeNamePrefix: '@_',
+          ignoreAttributes: false,
+        });
+
+        const res = '<?xml version="1.0" encoding="UTF-8"?>' + j2x.parse(json);
+        fs.writeFileSync(files.getFullPath(file.name), res, { encoding: 'utf-8' });
+      }
+    }
+  }
+}

--- a/lib/strava.js
+++ b/lib/strava.js
@@ -3,8 +3,10 @@
 const stravaClient        = require('./strava-client');
 const stravaUpload        = require('./strava-upload');
 const stravaFixActivities = require('./strava-fix-activities');
+const stravaPreprocess    = require('./strava-preprocess');
 
 module.exports = {
+  preprocess    : async () => { await stravaPreprocess() },
   upload        : async () => { await stravaUpload(stravaClient) }, 
   fixActivities : async () => { await stravaFixActivities(stravaClient) }, 
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,6 +116,11 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
+    "fast-xml-parser": {
+      "version": "3.17.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.6.tgz",
+      "integrity": "sha512-40WHI/5d2MOzf1sD2bSaTXlPn1lueJLAX6j1xH5dSAr6tNeut8B9ktEL6sjAK9yVON4uNj9//axOdBJUuruCzw=="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "fast-xml-parser": "^3.17.6",
     "prompts": "^2.4.0",
     "strava-v3": "^2.0.9"
   }


### PR DESCRIPTION
I'm submitting this pull request not so much to get it accepted, but more to make viewers aware of a potential fix if they were heavy users of Endomondo manual activities. As a user of "manual activities" in Endomondo I found many of my activities to not be included by this project, because the TCX files had one or zero trackpoints and the upload ignores these, or loses duration and distance information.

This pull request ([and the fork it comes from](https://github.com/ondkloss/StravaImporter)) solves this problem by overwriting the TCX with two trackpoints in these specific cases. These trackpoints causes the exercise to get both duration and distance if specified from the Endomondo source, by fetching it from the JSON.

Below are some other aspects of this pull request and fork to evaluate:
* Copied over "notes" from Endomondo to "description" in Strava
* Changed the activity name to include the original Endomondo name, as e.g. "Indoor rowing" information is lost by mapping to "Workout"
* Added more sports to the SPORTMAP

For any user of this, by all means, remember to:
* **Keep a backup of your files, as the TCX will be overwritten with the fixes**